### PR TITLE
fix build on debian-derived distros

### DIFF
--- a/tuimerge/build_curses_extra.py
+++ b/tuimerge/build_curses_extra.py
@@ -1,4 +1,6 @@
 import os
+import shlex
+import sysconfig
 from cffi import FFI
 ffibuilder = FFI()
 
@@ -10,8 +12,9 @@ ffibuilder.set_source(
     'tuimerge._curses_extra',
     '#include "curses_extra.h"',
     sources=[os.path.join(this_dir, 'curses_extra.c')],
-    libraries=['ncursesw'],
     include_dirs=[this_dir],
+    extra_compile_args=shlex.split(sysconfig.get_config_var('MODULE__CURSES_CFLAGS')),
+    extra_link_args=shlex.split(sysconfig.get_config_var('MODULE__CURSES_LDFLAGS')),
 )
 
 

--- a/tuimerge/build_curses_extra.py
+++ b/tuimerge/build_curses_extra.py
@@ -6,6 +6,8 @@ ffibuilder = FFI()
 
 
 this_dir = os.path.dirname(__file__)
+cflags = shlex.split(sysconfig.get_config_var('MODULE__CURSES_CFLAGS') or '')
+ldflags = shlex.split(sysconfig.get_config_var('MODULE__CURSES_LDFLAGS') or '')
 
 
 ffibuilder.set_source(
@@ -13,8 +15,8 @@ ffibuilder.set_source(
     '#include "curses_extra.h"',
     sources=[os.path.join(this_dir, 'curses_extra.c')],
     include_dirs=[this_dir],
-    extra_compile_args=shlex.split(sysconfig.get_config_var('MODULE__CURSES_CFLAGS')),
-    extra_link_args=shlex.split(sysconfig.get_config_var('MODULE__CURSES_LDFLAGS')),
+    extra_compile_args=cflags,
+    extra_link_args=ldflags,
 )
 
 

--- a/tuimerge/build_curses_extra.py
+++ b/tuimerge/build_curses_extra.py
@@ -10,7 +10,7 @@ ffibuilder.set_source(
     'tuimerge._curses_extra',
     '#include "curses_extra.h"',
     sources=[os.path.join(this_dir, 'curses_extra.c')],
-    libraries=['cursesw'],
+    libraries=['ncursesw'],
     include_dirs=[this_dir],
 )
 


### PR DESCRIPTION
I have done no research about this but Debian/Ubuntu don't seem to ship `libcursesw.a` (just `libcurses.a`) so how about we `-lncursesw` and see how that goes.

Maybe this breaks Arch-based distros? Hope not!

Fixes #60 